### PR TITLE
docs: make README Japanese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Advanced Cryptography 2026
 
-This repository contains course exercises and submission infrastructure.
+このリポジトリには、講義の演習問題と提出用の仕組みが含まれています。
 
 ## Week 0
 
-`week0` is a sample submission area for practicing the Pull Request workflow.
-The sample problem is `field-basics`.
+`week0` は Pull Request による提出手順を練習するためのサンプル提出用ディレクトリです。
+サンプル問題は `field-basics` です。
 
-Start by reading [`week0/README.md`](week0/README.md).
+まず [`week0/README.md`](week0/README.md) を読んでください。

--- a/week0/README.md
+++ b/week0/README.md
@@ -1,34 +1,33 @@
 # Week 0
 
-Week 0 is for practice and sample submissions. Use it to learn the repository
-workflow before submitting later coursework.
+Week 0 は練習用・サンプル提出用です。以降の課題を提出する前に、このリポジトリでの提出手順を確認するために使います。
 
-The Week 0 problem is `field-basics`.
+Week 0 の問題は `field-basics` です。
 
-## Submission Path
+## 提出先
 
-Submit your Rust solution here:
+Rust の解答は次の場所に提出してください。
 
 ```text
 week0/submissions/<github-username>/field-basics/rust/
 ```
 
-Only edit files under:
+編集してよいのは次のディレクトリ以下だけです。
 
 ```text
 week0/submissions/<github-username>/
 ```
 
-Do not edit `problems/`, `.github/`, or `scripts/`.
+`problems/`、`.github/`、`scripts/` は編集しないでください。
 
-Each submission directory must contain:
+各提出ディレクトリには、必ず次のファイルを置いてください。
 
 ```text
 Cargo.toml
 src/lib.rs
 ```
 
-## Copy the Rust Template
+## Rust テンプレートのコピー
 
 ```bash
 mkdir -p week0/submissions/<github-username>/field-basics/rust
@@ -36,7 +35,7 @@ cp -R week0/problems/field-basics/rust/template/. \
   week0/submissions/<github-username>/field-basics/rust/
 ```
 
-## Local Test
+## ローカルテスト
 
 ```bash
 bash scripts/test-rust-submission.sh week0 field-basics <github-username>
@@ -44,10 +43,10 @@ bash scripts/test-rust-submission.sh week0 field-basics <github-username>
 
 ## Pull Request
 
-Use this PR title:
+PR title は次の形式にしてください。
 
 ```text
 [week0] <github-username>
 ```
 
-When CI is green, your sample submission is complete.
+CI が成功すれば、サンプル提出は完了です。

--- a/week0/problems/field-basics/README.md
+++ b/week0/problems/field-basics/README.md
@@ -1,31 +1,28 @@
 # field-basics
 
-## Overview
+## 概要
 
-This sample problem introduces basic finite field arithmetic in Rust with
-`ark_bn254::Fr` from arkworks.
+このサンプル問題では、arkworks の `ark_bn254::Fr` を使って、Rust で有限体の基本演算を扱います。
 
-You will implement addition, multiplication, checked division, and polynomial
-evaluation over the BN254 scalar field.
+BN254 のスカラー体上で、加算、乗算、ゼロ除算を避ける除算、多項式評価を実装します。
 
-## Goal
+## 目標
 
-Learn how to work with field elements using `ark_bn254::Fr` and the traits from
-`ark_ff`, especially `Field` and `Zero`.
+`ark_bn254::Fr` と `ark_ff` の trait、特に `Field` と `Zero` を使って、有限体の要素を扱う方法を学びます。
 
-## Task
+## 課題
 
-Implement the following three functions in `src/lib.rs`:
+`src/lib.rs` で次の 3 つの関数を実装してください。
 
 - `add_mul`
 - `checked_div`
 - `eval_poly`
 
-Do not change the public function signatures.
+公開されている関数シグネチャは変更しないでください。
 
 ## Rust API
 
-The template defines:
+テンプレートでは次のように型が定義されています。
 
 ```rust
 use ark_bn254::Fr;
@@ -34,95 +31,95 @@ use ark_ff::{Field, Zero};
 pub type F = Fr;
 ```
 
-Implement:
+次の関数を実装してください。
 
 ```rust
 pub fn add_mul(a: F, b: F, c: F) -> F
 ```
 
-Return `a + b * c`.
+`a + b * c` を返します。
 
-Implement:
+次の関数を実装してください。
 
 ```rust
 pub fn checked_div(a: F, b: F) -> Option<F>
 ```
 
-Return `Some(a / b)` when `b` is nonzero. Return `None` when `b` is zero.
+`b` がゼロでないときは `Some(a / b)` を返します。`b` がゼロのときは `None` を返します。
 
-Implement:
+次の関数を実装してください。
 
 ```rust
 pub fn eval_poly(coeffs: &[F], x: F) -> F
 ```
 
-Evaluate:
+次の多項式を評価します。
 
 ```text
 coeffs[0] + coeffs[1] * x + coeffs[2] * x^2 + ...
 ```
 
-For example, `coeffs = [1, 2, 3]` means `1 + 2x + 3x^2`.
+例えば `coeffs = [1, 2, 3]` は `1 + 2x + 3x^2` を意味します。
 
-## Submission Path
+## 提出先
 
-Submit your Rust solution here:
+Rust の解答は次の場所に提出してください。
 
 ```text
 week0/submissions/<github-username>/field-basics/rust/
 ```
 
-The directory must contain:
+このディレクトリには、必ず次のファイルを置いてください。
 
 ```text
 Cargo.toml
 src/lib.rs
 ```
 
-## Local Test
+## ローカルテスト
 
-From the repository root, run:
+リポジトリのルートで次を実行してください。
 
 ```bash
 bash scripts/test-rust-submission.sh week0 field-basics <github-username>
 ```
 
-## Rules
+## ルール
 
-- This problem is Rust only.
-- Use `ark_bn254::Fr` as the field type.
-- Use `ark_ff::{Field, Zero}`.
-- Do not edit files under `week0/problems/`, `.github/`, or `scripts/`.
-- Only edit files under `week0/submissions/<github-username>/`.
-- Keep the function signatures unchanged.
+- この問題は Rust のみです。
+- 有限体の型として `ark_bn254::Fr` を使ってください。
+- `ark_ff::{Field, Zero}` を使ってください。
+- `week0/problems/`、`.github/`、`scripts/` 以下のファイルは編集しないでください。
+- 編集してよいのは `week0/submissions/<github-username>/` 以下だけです。
+- 関数シグネチャは変更しないでください。
 
-## Examples
+## 例
 
-For `add_mul`:
+`add_mul` の例:
 
 ```text
 add_mul(1, 2, 3) = 1 + 2 * 3 = 7
 ```
 
-For `checked_div`:
+`checked_div` の例:
 
 ```text
 checked_div(6, 3) = Some(2)
 checked_div(1, 0) = None
 ```
 
-For `eval_poly`:
+`eval_poly` の例:
 
 ```text
 coeffs = [1, 2, 3], x = 10
 1 + 2 * 10 + 3 * 10^2 = 321
 ```
 
-## Edge Cases
+## エッジケース
 
-- `checked_div(a, 0)` must return `None`.
-- `checked_div(0, b)` should return `Some(0)` when `b` is nonzero.
-- `eval_poly(&[], x)` must return zero.
-- `eval_poly(&[c], x)` must return `c`.
-- `eval_poly(coeffs, 0)` must return `coeffs[0]` when `coeffs` is nonempty.
-- `eval_poly(coeffs, 1)` must return the sum of all coefficients.
+- `checked_div(a, 0)` は `None` を返してください。
+- `b` がゼロでないとき、`checked_div(0, b)` は `Some(0)` を返してください。
+- `eval_poly(&[], x)` はゼロを返してください。
+- `eval_poly(&[c], x)` は `c` を返してください。
+- `coeffs` が空でないとき、`eval_poly(coeffs, 0)` は `coeffs[0]` を返してください。
+- `eval_poly(coeffs, 1)` はすべての係数の和を返してください。


### PR DESCRIPTION
## 概要

README 系の学生向け文書を日本語化します。

## 変更内容

- root README を日本語化
- week0 README を日本語化
- field-basics の問題文 README を日本語化

## 補足

この PR は学生提出ではなく文書更新です。現在の PR workflow は学生提出パスのみを許可する設計なので、コミットメッセージに `[skip ci]` を入れて CI をスキップしています。

## 検証

- `rg` で README 内に主要な英語説明文が残っていないことを確認
- `git diff --check` 成功