### PR TITLE
fix(ci): fetch full base history for PR diffs

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -37,7 +37,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          git fetch --no-tags --depth=1 origin "$BASE_REF"
+          git fetch --no-tags origin "$BASE_REF"
 
           changed_files="$(mktemp)"
           submissions="$(mktemp)"


### PR DESCRIPTION
## Summary

Fix the `no merge base` CI error by fetching the base branch without `--depth=1`.

Reproduced the issue in a fork and confirmed that the workflow passes after this change.
Reproduction: https://github.com/da1suk8/advanced-cryptography-2026/pull/1