### PR TITLE
chore: update gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 __pycache__/
 *.pyc
 
-week5/submissions/test/
+# macOS metadata
+.DS_Store
+._*


### PR DESCRIPTION
## 概要

- `week5/submissions/test/` の除外設定を削除
- macOS が生成する標準的なメタデータファイル `.DS_Store` と `._*` を除外対象に追加

## 背景

提出用の `week5/submissions/test/` が誤って Git の追跡対象外になっており、一方で macOS のメタデータファイルを除外する設定がありませんでした。

## 影響

`week5/submissions/test/` 配下をコミットできるようになります。また、macOS のメタデータファイルが誤ってコミットされるのを防ぎます。

## 検証

- `git diff origin/main...HEAD --check`
- `git check-ignore -v --no-index .DS_Store nested/.DS_Store nested/._metadata`
- `git check-ignore -v --no-index week5/submissions/test/example.txt` が終了コード 1 となり、除外されないことを確認
- GitHub Actions `test-submissions` は失敗（現在のCIポリシーが `.gitignore` を変更許可パスに含めていないため、`Unauthorized path: .gitignore` で終了）
